### PR TITLE
Adjust live chat fonts for 10px rem base

### DIFF
--- a/data/mail_templates.xml
+++ b/data/mail_templates.xml
@@ -10,15 +10,15 @@
         <td align="center" style="min-width: 590px;">
             <table border="0" cellpadding="0" cellspacing="0" width="100%" style="background-color: white; padding: 0; border-collapse:separate;">
                 <tr><td valign="middle">
-                    <span style="font-size: 10px;">Livechat Conversation</span><br/>
-                    <span style="font-size: 20px; font-weight: bold;">
+                    <span style="font-size: 1rem;">Livechat Conversation</span><br/>
+                    <span style="font-size: 2rem; font-weight: bold;">
                         <t t-esc="company.name"/>
                     </span>
                 </td><td valign="middle" align="right" t-if="not company.uses_default_logo">
                     <img t-att-src="'/logo.png?company=%s' % company.id" style="padding: 0px; margin: 0px; height: 48px;" t-att-alt="'%s' % company.name"/>
                 </td></tr>
                 <tr><td colspan="2" style="text-align:center;">
-                  <hr width="100%" style="background-color:rgb(204,204,204);border:medium none;clear:both;display:block;font-size:0px;min-height:1px;line-height:0; margin:4px 0px 32px 0px;"/>
+                  <hr width="100%" style="background-color:rgb(204,204,204);border:medium none;clear:both;display:block;font-size:0;min-height:1px;line-height:0; margin:4px 0px 32px 0px;"/>
                 </td></tr>
             </table>
         </td>
@@ -30,7 +30,7 @@
     <t t-set="left" t-value="'border-left: thin solid #dee2e6;'" />
     <tr>
         <td style="padding: 0 50px;">
-            <div style="font-size: 13px; padding: 10px 0;">
+            <div style="font-size: 1.3rem; padding: 10px 0;">
                 <span>Hello,</span><br />Here's a copy of your conversation with
                 <!-- sudo: res.users - visitor can access the name of the operator -->
                 <span t-esc="channel.livechat_operator_id.sudo().user_livechat_username or channel.livechat_operator_id.sudo().name"/>, on the
@@ -52,16 +52,16 @@
                         <td t-att-style="'padding-left: 5px; margin: 0px;' + top">
                             <strong t-esc="author_name"/>
                         </td>
-                        <td  t-att-style="'font-size: 13px; padding: 5px;' + top + right" align="right"><span t-field="message.date"/></td>
+                        <td  t-att-style="'font-size: 1.3rem; padding: 5px;' + top + right" align="right"><span t-field="message.date"/></td>
                     </tr>
                     <tr>
                         <td valign="top" colspan="2" t-att-style="'padding-left: 5px;' + bottom + right">
-                            <span t-field="message.body" style="font-size: 13px;"/>
+                            <span t-field="message.body" style="font-size: 1.3rem;"/>
                         </td>
                     </tr>
                 </t>
             </table>
-            <div style="font-size: 13px; padding: 30px 0;">
+            <div style="font-size: 1.3rem; padding: 30px 0;">
                 <span>Best regards,</span><br /><br />
                 <span t-field="company.name"/>
             </div>
@@ -69,8 +69,8 @@
     </tr>
     <!-- FOOTER -->
     <tr>
-        <td align="center" style="min-width: 590px; padding: 0 8px 0 8px; font-size:11px;">
-            <hr width="100%" style="background-color:rgb(204,204,204);border:medium none;clear:both;display:block;font-size:0px;min-height:1px;line-height:0; margin: 16px 0px 4px 0px;"/>
+        <td align="center" style="min-width: 590px; padding: 0 8px 0 8px; font-size:1.1rem;">
+            <hr width="100%" style="background-color:rgb(204,204,204);border:medium none;clear:both;display:block;font-size:0;min-height:1px;line-height:0; margin: 16px 0px 4px 0px;"/>
             <b t-esc="company.name"/><br/>
             <div style="color: #999999;">
                 <t t-esc="company.phone"/>

--- a/static/src/embed/common/emoji_picker.scss
+++ b/static/src/embed/common/emoji_picker.scss
@@ -1,3 +1,3 @@
 .o-EmojiPicker {
-    font-size: 1.2em;
+    font-size: 1.68rem;
 }

--- a/static/src/embed/common/livechat_button.scss
+++ b/static/src/embed/common/livechat_button.scss
@@ -1,6 +1,6 @@
 .o-livechat-LivechatButton {
     min-width: 100px;
-    font-size: 14px;
+    font-size: 1.4rem;
     z-index: 5;
     transition: filter 0.3s;
 

--- a/static/src/embed/common/livechat_button.xml
+++ b/static/src/embed/common/livechat_button.xml
@@ -11,7 +11,7 @@
         t-on-click="onClick"
         title="Drag to Move"
     >
-        <i class="fa fa-commenting" style="font-size: 24px;"/>
+        <i class="fa fa-commenting" style="font-size: 2.4rem;"/>
         <div t-if="livechatService.rule?.action === 'display_button_and_text'" class="o-livechat-LivechatButton-notification text-nowrap position-absolute bg-100 py-2 px-3 rounded" style="max-width: 75vw;" t-att-class="{'o-livechat-LivechatButton-animate': state.animateNotification}">
             <p class="m-0 text-dark text-truncate" t-esc="livechatService.options.button_text"/>
         </div>

--- a/static/src/embed/common/scss/shadow.scss
+++ b/static/src/embed/common/scss/shadow.scss
@@ -1,7 +1,8 @@
 // Duplicate :root/body rules into :host ruleset in order to make them work
 // in the shadow DOM.
 
-$o-livechat-font-size: 14px !default;
+$o-livechat-font-size: 1.4rem !default;
+$font-size-root: 62.5% !default;
 
 // Source: bootstrap/scss/_root.scss
 :host,

--- a/views/im_livechat_channel_templates.xml
+++ b/views/im_livechat_channel_templates.xml
@@ -27,7 +27,7 @@
                     <style type="text/css">
                         body {
                             height: 100%;
-                            font-size: 16px;
+                            font-size: 1.6rem;
                             font-weight: 400;
                             font-family: "Lato", "Lucida Grande", "Helvetica neue", "Helvetica", "Verdana", "Arial", sans-serif;
                             overflow: hidden;
@@ -63,12 +63,12 @@
                             text-align: center;
                         }
                         .channel_name {
-                            font-size: clamp(2.5rem, 6vw, 3.5rem);
+                            font-size: clamp(4rem, 6vw, 5.6rem);
                             overflow-wrap: break-word;
                         }
                         .main div {
                             font-style: italic;
-                            font-size: 1rem;
+                            font-size: 1.6rem;
                         }
                     </style>
                 </head>


### PR DESCRIPTION
## Summary
- Align shadow DOM root and host fonts with 10px = 1rem
- Convert live chat button, emoji picker, and templates to use rem-based sizing
- Update support and mail templates to respect the new font scaling

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_e_68a681edc0008320873a534c40394bd8